### PR TITLE
persistence: lock matrix reads during encode

### DIFF
--- a/pkg/persistence/store.go
+++ b/pkg/persistence/store.go
@@ -180,7 +180,7 @@ func NewStoreWithDurability(basePath string, compress bool, durability Durabilit
 
 // Save persists a matrix to disk
 func (s *Store) Save(matrix *core.Matrix) error {
-	data, err := s.codec.Encode(matrix)
+	data, err := s.encodeMatrixLocked(matrix)
 	if err != nil {
 		return fmt.Errorf("encode failed: %w", err)
 	}
@@ -198,7 +198,7 @@ func (s *Store) Save(matrix *core.Matrix) error {
 
 // SaveAsync queues a matrix for async persistence.
 func (s *Store) SaveAsync(matrix *core.Matrix) error {
-	data, err := s.codec.Encode(matrix)
+	data, err := s.encodeMatrixLocked(matrix)
 	if err != nil {
 		return fmt.Errorf("encode failed: %w", err)
 	}
@@ -226,7 +226,7 @@ func (s *Store) flushUser(indexID core.IndexID) error {
 	s.writeMu.Unlock()
 
 	// Encode matrix
-	data, err := s.codec.Encode(matrix)
+	data, err := s.encodeMatrixLocked(matrix)
 	if err != nil {
 		return fmt.Errorf("encode failed: %w", err)
 	}
@@ -237,7 +237,9 @@ func (s *Store) flushUser(indexID core.IndexID) error {
 	}
 
 	// Update index
+	matrix.RLock()
 	snapshot := CreateSnapshot(matrix)
+	matrix.RUnlock()
 	s.indexMu.Lock()
 	s.index[indexID] = &snapshot
 	s.totalWrites++
@@ -245,6 +247,12 @@ func (s *Store) flushUser(indexID core.IndexID) error {
 
 	// Save index
 	return s.saveIndex()
+}
+
+func (s *Store) encodeMatrixLocked(matrix *core.Matrix) ([]byte, error) {
+	matrix.RLock()
+	defer matrix.RUnlock()
+	return s.codec.Encode(matrix)
 }
 
 // FlushAll writes all pending matrices

--- a/pkg/persistence/store_test.go
+++ b/pkg/persistence/store_test.go
@@ -143,6 +143,70 @@ func TestStoreSaveAsync(t *testing.T) {
 	}
 }
 
+func TestStoreSaveAsyncBlocksOnMatrixWriteLock(t *testing.T) {
+	store, tmpDir := setupTestStore(t)
+	defer os.RemoveAll(tmpDir)
+
+	m := core.NewMatrix("user-1", core.DefaultBounds())
+	m.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- store.SaveAsync(m)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SaveAsync should wait while matrix write lock is held, got early result: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked
+	}
+
+	m.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SaveAsync failed after lock release: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("SaveAsync did not resume after lock release")
+	}
+}
+
+func TestStoreFlushAllBlocksOnMatrixWriteLock(t *testing.T) {
+	store, tmpDir := setupTestStore(t)
+	defer os.RemoveAll(tmpDir)
+
+	m := core.NewMatrix("user-1", core.DefaultBounds())
+	if err := store.SaveAsync(m); err != nil {
+		t.Fatalf("SaveAsync failed: %v", err)
+	}
+
+	m.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- store.FlushAll()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("FlushAll should wait while matrix write lock is held, got early result: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked
+	}
+
+	m.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("FlushAll failed after lock release: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("FlushAll did not resume after lock release")
+	}
+}
+
 func TestStoreListIndexes(t *testing.T) {
 	store, tmpDir := setupTestStore(t)
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
## Summary
Fix persistence race that can crash QubicDB under heavy write load.

During background persist, the daemon called `SaveAsync(worker.Matrix())` while other worker operations could mutate matrix maps. Msgpack encode iterated over maps concurrently with writes, causing:

`fatal error: concurrent map iteration and map write`

## Root Cause
`Store.SaveAsync` / `Store.Save` / `flushUser` encoded live matrix pointers without taking matrix read lock.

## Changes
- Add matrix read-lock during encode in persistence store:
  - `Save`
  - `SaveAsync`
  - `flushUser`
- Add read-lock around `CreateSnapshot(matrix)` in `flushUser`.
- Introduce helper:
  - `encodeMatrixLocked(matrix *core.Matrix) ([]byte, error)`

## Why this fix
Encoding now happens under `matrix.RLock()`, preventing concurrent map iteration while writes hold `matrix.Lock()`.

## Validation

### Before (old `store.go`)
```bash
go test ./pkg/persistence -run 'TestStoreSaveAsyncBlocksOnMatrixWriteLock|TestStoreFlushAllBlocksOnMatrixWriteLock' -count=1
